### PR TITLE
Fix port number to use correct endian

### DIFF
--- a/src/isns.c
+++ b/src/isns.c
@@ -354,7 +354,7 @@ int isns_target_register(char *name)
 	uint16_t flags = 0, length = 0;
 	struct isns_hdr *hdr = (struct isns_hdr *) buf;
 	struct isns_tlv *tlv;
-	uint32_t port = 3260; /* FIXME: */
+	uint32_t port = htonl(3260); /* FIXME: */
 	uint32_t node = htonl(ISNS_NODE_TARGET);
 	uint32_t type = htonl(2);
 	int err;


### PR DESCRIPTION
We've tested with a Windows 2008 R2 iSNS server and noticed that
all targets were listed with port 0 as the port number instead of
3260. We captured a wireshark trace and compared to another iSNS
target and noticed the port was little endian in our case and
big endian in the working case.

I'm a little confused because based on a quick glance at RFC 4171
section 6.3.2 (http://tools.ietf.org/html/rfc4171#section-6.3.2)
I would have expected a shift to be required, however we confirmed
that the implementation matches the working iSNS target when
implemented as above and the value passed to htonl is the one
displayed in the Windows iSNS server as the port number for each target.
