### PR TITLE
Fix missing vsyslog declaration

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -6,6 +6,7 @@
  */
 
 #define _DEFAULT_SOURCE
+#define _BSD_SOURCE
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>


### PR DESCRIPTION
I'm not sure why nobody else is hitting this, but on Fedora 20 at least
defining _BSD_SOURCE seems to be needed for vsyslog to be defined.

Signed-off-by: Andy Grover agrover@redhat.com
