### PR TITLE
Add _POSIX_C_SOURCE define for getaddrinfo(3)

### DIFF
--- a/src/isns.c
+++ b/src/isns.c
@@ -9,6 +9,7 @@
  */
 
 #define _POSIX_SOURCE
+#define _POSIX_C_SOURCE 200112L
 #include <errno.h>
 #include <inttypes.h>
 #include <limits.h>


### PR DESCRIPTION
The netdb library has been updated so that getaddrinfo()
and friends (like gai_strerror()) are not defined in
netdb.h unless one of the following is true:

  _XOPEN_SOURCE >= 600 || _POSIX_C_SOURCE >= 200112L

whereas it used to be:

  _POSIX_C_SOURCE >= 1 || _XOPEN_SOURCE || _POSIX_SOURCE

This adds the proper define to isns.c where netdb is used.