### PR TITLE
Fix a small wording issue in the README and manpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ An iSNS client for the Linux LIO iSCSI target
 ---------------------------------------------
 
 Target-isns is an Internet Storage Name Service (iSNS) client for the
-Linux LIO iSCSI target. It allows to register LIO iSCSI targets to an
-iSNS server.
+Linux LIO iSCSI target. It allows registering LIO iSCSI targets with
+an iSNS server.
 
 The iSNS protocol is specified in
 [RFC 4171](http://tools.ietf.org/html/rfc4171) and its purpose is to

--- a/target-isns.8
+++ b/target-isns.8
@@ -6,12 +6,12 @@
 .B target-isns [OPTION]
 .SH DESCRIPTION
 .B target-isns
-allows to register LIO iSCSI targets to an iSNS server.
+allows registering LIO iSCSI targets with an iSNS server.
 .PP
 The Internet Storage Name Service (iSNS, RFC 4171) protocol makes
 easier to discover, manage and configure iSCSI devices.
 .PP
-With iSNS, iSCSI targets can be registered to a central iSNS server
+With iSNS, iSCSI targets can be registered with a central iSNS server
 and initiators can be configured to discover the targets by asking the
 iSNS server.
 .SH OPTIONS


### PR DESCRIPTION
The same issue in three places. Saying 'registered with' rather than
'registered to' reads a little more smoothly.

Signed-off-by: Andy Grover <agrover@redhat.com>