### PR TITLE
Set C_STANDARD target property only for CMake 3.1 or newer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,16 @@ project(target-isns "C")
 set(TARGET_ISNS_VERSION "0.6.1")
 
 cmake_minimum_required(VERSION 2.8)
+
+set(IS_CMAKE_31 false)
+if(NOT CMAKE_VERSION VERSION_LESS "3.1")
+  set(IS_CMAKE_31 true)
+endif()
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
+if(NOT IS_CMAKE_31)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror -std=c99")
+endif()
 
 option(SUPPORT_SYSTEMD "Support service control via systemd" OFF)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,9 @@ add_executable(target-isns
   log.c
   util.c
   target-isns.c)
-set_property(TARGET target-isns PROPERTY C_STANDARD 99)
+if(IS_CMAKE_31)
+  set_property(TARGET target-isns PROPERTY C_STANDARD 99)
+endif()
 target_link_libraries(target-isns
   ccan)
 install(TARGETS target-isns RUNTIME DESTINATION bin)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,8 @@ add_executable(test-isns-fuzzing
   ../src/isns_proto.c
   ../src/itimer.c
   ../src/log.c)
-set_property(TARGET test-isns-fuzzing PROPERTY C_STANDARD 99)
+if(IS_CMAKE_31)
+  set_property(TARGET test-isns-fuzzing PROPERTY C_STANDARD 99)
+endif()
 target_link_libraries(test-isns-fuzzing
   ccan)


### PR DESCRIPTION
The C_STANDARD target property was added in CMake 3.1. The compilation
using older versions of CMake, like 2.8.12 on Ubuntu 14.04 fails because
the -std=c99 C flag is not added. To fix the problem, for CMake older
than 3.1, add the -std=c99 to CMAKE_C_FLAGS, for newer versions set
C_STANDARD target property.

Signed-off-by: Victor Dodon <dodonvictor@gmail.com>