### PR TITLE
v2: Fix compilation for CMake older than 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ set(TARGET_ISNS_VERSION "0.6.1")
 
 cmake_minimum_required(VERSION 2.8)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
+if(CMAKE_VERSION VERSION_LESS "3.1")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+endif()
 
 option(SUPPORT_SYSTEMD "Support service control via systemd" OFF)
 


### PR DESCRIPTION
The C_STANDARD target property was added in CMake 3.1. The compilation
using older versions of CMake, like 2.8.12 on Ubuntu 14.04 fails because
the -std=c99 C flag is not added. The fix is to add -std=c99 to CMAKE_C_FLAGS
for older cmake versions.

Signed-off-by: Victor Dodon <dodonvictor@gmail.com>