### PR TITLE
Fix warnings from newer versions of cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix warnings about CMake cmake_minimum_required() location
+  and version number.
 
 ## [0.6.8] - 2020-05-08
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,11 @@
 # SPDX-License-Identifier:	GPL-2.0+
 #
 
+cmake_minimum_required(VERSION 3.5)
+
 project(target-isns "C")
 set(TARGET_ISNS_VERSION "0.6.8")
 
-cmake_minimum_required(VERSION 3.1)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
 
 option(SUPPORT_SYSTEMD "Support service control via systemd" OFF)


### PR DESCRIPTION
Newer version of cmake complain about the CMakeLists.txt file entry for cmake_minimum_required(). This fixes those warnings (using cmake versions 3.17 to 3.20).