### PR TITLE
Two small fixes to make gcc and cmake happy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier:	GPL-2.0+
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(target-isns "C")
 set(TARGET_ISNS_VERSION "0.6.8")

--- a/src/configfs.c
+++ b/src/configfs.c
@@ -238,7 +238,7 @@ static struct tpg *configfs_tpg_init(struct target *tgt, uint16_t tpg_tag)
 	return tpg;
 }
 
-static int get_portal(const char *str, int *af, char *ip_addr, uint16_t *port)
+static int get_portal(char *str, int *af, char *ip_addr, uint16_t *port)
 {
 	uint8_t addr[sizeof(struct in6_addr)];
 	char *p = strrchr(str, ':');


### PR DESCRIPTION
Up required cmake version to 3.10, and remove "const" qualifier in get_portal().